### PR TITLE
Fix css for 'cyphertext' class

### DIFF
--- a/src/epub/css/local.css
+++ b/src/epub/css/local.css
@@ -120,14 +120,14 @@ p span.i2{
 	width: 95%;
 }
 
-.cyphertext p,
-.cyphertext td{
+.ciphertext p,
+.ciphertext td{
 	text-indent: 0;
 	vertical-align: top;
 	word-break: break-all;
 }
 
-.cyphertext td:first-child{
+.ciphertext td:first-child{
 	font-style: italic;
 	width: 5em;
 	word-break: normal;


### PR DESCRIPTION
A recent change broke the css for the 'cyphertext' class. I've updated the name of the class in local.css to correct this issue.